### PR TITLE
Remove unused dependency `gulp-shell`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,6 @@ var notify = require('gulp-notify');
 var concat = require('gulp-concat');
 var cssmin = require('gulp-cssmin');
 var gutil = require('gulp-util');
-var shell = require('gulp-shell');
 var glob = require('glob');
 var livereload = require('gulp-livereload');
 var jasminePhantomJs = require('gulp-jasmine2-phantomjs');

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "gulp-jasmine2-phantomjs": "^0.1.1",
     "gulp-livereload": "^2.1.1",
     "gulp-notify": "^1.4.2",
-    "gulp-shell": "^0.2.10",
     "gulp-streamify": "0.0.5",
     "gulp-uglify": "^0.3.1",
     "gulp-util": "^3.0.0",


### PR DESCRIPTION
The dependency `gulp-shell` is unused. This commit removes it.