### PR TITLE
Switch from the deprecated 'reactify' module to 'babelify'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,7 @@ var gulp = require('gulp');
 var source = require('vinyl-source-stream'); // Used to stream bundle for further handling
 var browserify = require('browserify');
 var watchify = require('watchify');
-var reactify = require('reactify');
+var babelify = require('babelify');
 var gulpif = require('gulp-if');
 var uglify = require('gulp-uglify');
 var streamify = require('gulp-streamify');
@@ -28,7 +28,7 @@ var browserifyTask = function (options) {
   // Our app bundler
 	var appBundler = browserify({
 		entries: [options.src], // Only need initial file, browserify finds the rest
-   	transform: [reactify], // We want to convert JSX to normal javascript
+   	transform: [[babelify, {presets: ['react']}]], // We want to convert JSX to normal javascript
 		debug: options.development, // Gives us sourcemapping
 		cache: {}, packageCache: {}, fullPaths: options.development // Requirement of watchify
 	});
@@ -71,7 +71,7 @@ var browserifyTask = function (options) {
 		var testBundler = browserify({
 			entries: testFiles,
 			debug: true, // Gives us sourcemapping
-			transform: [reactify],
+			transform: [[babelify, {presets: ['react']}]],
 			cache: {}, packageCache: {}, fullPaths: true // Requirement of watchify
 		});
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "author": "Christian Alfoni",
   "license": "ISC",
   "devDependencies": {
+    "babel-preset-react": "^6.5.0",
+    "babelify": "^7.2.0",
     "browserify": "^10.2.1",
     "glob": "^4.0.6",
     "gulp": "^3.8.9",
@@ -20,7 +22,6 @@
     "gulp-uglify": "^0.3.1",
     "gulp-util": "^3.0.0",
     "phantomjs": "^1.9.12",
-    "reactify": "^0.15.2",
     "vinyl-source-stream": "^0.1.1",
     "watchify": "^2.1.1"
   },


### PR DESCRIPTION
'reactify' is using the deprecated package 'react-tools' and is causing problems when using references (since it's including react twice).
See https://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html for more information