### PR TITLE
Enabling gulp-uglify handle es6 syntax

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ var reactify = require('reactify');
 var gulpif = require('gulp-if');
 var uglify = require('gulp-uglify');
 var streamify = require('gulp-streamify');
+var babel = require('gulp-babel');
 var notify = require('gulp-notify');
 var concat = require('gulp-concat');
 var cssmin = require('gulp-cssmin');
@@ -45,6 +46,7 @@ var browserifyTask = function (options) {
     appBundler.bundle()
       .on('error', gutil.log)
       .pipe(source('main.js'))
+      .pipe(streamify(babel({presets: ['es2015']})))
       .pipe(gulpif(!options.development, streamify(uglify())))
       .pipe(gulp.dest(options.dest))
       .pipe(gulpif(options.development, livereload()))

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "watchify": "^2.1.1"
   },
   "dependencies": {
+    "babel-preset-es2015": "^6.9.0",
+    "gulp-babel": "^6.1.2",
     "react": "^0.13.3"
   }
 }


### PR DESCRIPTION
uglify can't parse ES6 syntax and throws an unknown token error. Converting ES6 to ES5 before uglifying in the deploy process 
